### PR TITLE
Add option to disable logging of packet contents

### DIFF
--- a/ACSRelay/ACSRelay/log.cpp
+++ b/ACSRelay/ACSRelay/log.cpp
@@ -333,8 +333,12 @@ void Log::SetOutputFile ( const std::string fn )
 
 std::string Log::_log_packet ( char* msg, long len )
 {
+
     std::ostringstream r;
 
+#ifdef DISABLE_PACKET_LOGS
+	r << "\n\tPacket type: " << *(reinterpret_cast<int8_t*> ( msg ));
+#else
     switch ( *(reinterpret_cast<int8_t*> ( msg )) )
     {
         case ACSProtocol::ACSP_BROADCAST_CHAT:
@@ -348,7 +352,7 @@ std::string Log::_log_packet ( char* msg, long len )
             std::u32string utf32_string ( reinterpret_cast<char32_t*>(msg + 2), namelen );
             convert32 converter;
             std::string ws = converter.to_bytes(utf32_string);
-            
+
             r << L"\n\tMESSAGE: \"" << ws << "\"";
         }; break;
         case ACSProtocol::ACSP_CAR_INFO:
@@ -865,6 +869,8 @@ std::string Log::_log_packet ( char* msg, long len )
             r << "\n\tUnknown or corrupt packet";
         } break;
     }
+
+#endif // DISABLE_PACKET_LOGS
 
     return r.str ();
 }

--- a/ACSRelay/ACSRelay/log.h
+++ b/ACSRelay/ACSRelay/log.h
@@ -56,8 +56,10 @@ private:
         T1 _arg1;
         T2 _arg2;
     };
-    
+
 public:
+
+#ifndef DISABLE_PACKET_LOGS
     /**
      * @brief std::codecvt implementation with a public destructor.
      */
@@ -68,11 +70,14 @@ public:
     /**
      * @brief Used to convert from UTF-16 to standard char.
      */
-    typedef std::wstring_convert<codecvt<char16_t,char,std::mbstate_t>,char16_t> convert16;
+    typedef wstring_convert<codecvt<char16_t,char,std::mbstate_t>,char16_t> convert16;
     /**
      * @brief Used to convert from UTF-32 to standard char.
      */
     typedef std::wstring_convert<codecvt<char32_t,char,std::mbstate_t>,char32_t> convert32;
+
+#endif // DISABLE_PACKET_LOGS
+
     /**
      * @brief Possible levels of verbosity for the log functions.
      * Lower values have a higher priority. For example, if a message with
@@ -241,7 +246,7 @@ public:
      * @param fn Path to the new log file name.
      */
     static void SetOutputFile ( const std::string fn );
-    
+
 private:
     Log ();
 
@@ -263,16 +268,16 @@ private:
     friend class _log_manip;
 
     static std::string _log_packet ( char* msg, long len );
-    
+
     std::ostream *mOutput;
     std::ofstream *mLogFile;
-    
+
     enum OutputLevel mLevel;
     enum OutputLevel mRequestedLevel;
-    
+
     std::string mLogFilename;
     bool mFileOutputEnabled;
-    
+
     bool mTreatWarningsAsErrors;
 };
 

--- a/ACSRelay/CMakeLists.txt
+++ b/ACSRelay/CMakeLists.txt
@@ -12,6 +12,12 @@ configure_file(
 	"${PROJECT_BINARY_DIR}/${SOURCE_DIR}/cmake_config.h"
 )
 
+option(PACKET_LOGGING "Enable logging of packet contents" TRUE)
+
+if(NOT PACKET_LOGGING)
+    add_definitions(-DDISABLE_PACKET_LOGS)
+endif()
+
 include_directories(${SOURCE_DIR})
 
 set(project_SOURCES


### PR DESCRIPTION
Note: This also provides a workaround for an issue where certain implementations of glibc do not implement wstring_convert (for example, on Fedora 21)
